### PR TITLE
Dpgmm

### DIFF
--- a/abundance_plot_utils.py
+++ b/abundance_plot_utils.py
@@ -167,6 +167,10 @@ def sum_on_phylogeny(dataframe, phylo_level, name):
 
 
 def aggregate_mixed_phylogeny(dataframe, phylo_dict):
+    # original inspiration:
+    #{'Phylum':['Bacteroidetes'],
+    # 'Order':['Burkholderiales','Methylophilales', 'Methylococcales']}
+
     # Loop over the different phylogenetic levels specified.
     # Make a list of each dataframe that will be concatenated.
     reduced_data = []

--- a/calculate_abundances.ipynb
+++ b/calculate_abundances.ipynb
@@ -55,9 +55,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/janet/.virtualenvs/meta4/bin/python3\n",
-      "3.5.1 (v3.5.1:37a07cee5969, Dec  5 2015, 21:12:44) \n",
-      "[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]\n"
+      "//anaconda/envs/meta4/bin/python\n",
+      "3.5.1 |Continuum Analytics, Inc.| (default, Dec  7 2015, 11:24:55) \n",
+      "[GCC 4.2.1 (Apple Inc. build 5577)]\n"
      ]
     }
    ],
@@ -78,7 +78,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/janet/elvizAnalysis\n"
+      "/Users/jmatsen/programming/elvizAnalysis\n"
      ]
     }
    ],
@@ -241,11 +241,11 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "from abundance_utils import make_directory\n",
+    "from elviz_utils import make_directory\n",
     "\n",
     "make_directory(dirpath=\"./plots\")\n",
     "make_directory(dirpath='results')"
@@ -684,7 +684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -768,9 +768,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -781,103 +781,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>ID</th>\n",
-       "      <th>rep</th>\n",
-       "      <th>week</th>\n",
-       "      <th>oxy</th>\n",
-       "      <th>Genus</th>\n",
-       "      <th>Length</th>\n",
-       "      <th>abundance</th>\n",
-       "      <th>project</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>2432</th>\n",
-       "      <td>106_HOW12</td>\n",
-       "      <td>4</td>\n",
-       "      <td>12</td>\n",
-       "      <td>High</td>\n",
-       "      <td>Methylobacter</td>\n",
-       "      <td>4325001</td>\n",
-       "      <td>0.701923</td>\n",
-       "      <td>1056226</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>42797</th>\n",
-       "      <td>76_LOW10</td>\n",
-       "      <td>4</td>\n",
-       "      <td>10</td>\n",
-       "      <td>Low</td>\n",
-       "      <td>Methylobacter</td>\n",
-       "      <td>6062067</td>\n",
-       "      <td>0.701577</td>\n",
-       "      <td>1056166</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>50891</th>\n",
-       "      <td>94_HOW11</td>\n",
-       "      <td>4</td>\n",
-       "      <td>11</td>\n",
-       "      <td>High</td>\n",
-       "      <td>Methylobacter</td>\n",
-       "      <td>5268714</td>\n",
-       "      <td>0.698849</td>\n",
-       "      <td>1056202</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>45856</th>\n",
-       "      <td>82_HOW10</td>\n",
-       "      <td>4</td>\n",
-       "      <td>10</td>\n",
-       "      <td>High</td>\n",
-       "      <td>Methylobacter</td>\n",
-       "      <td>5488758</td>\n",
-       "      <td>0.693746</td>\n",
-       "      <td>1056178</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26673</th>\n",
-       "      <td>40_LOW7</td>\n",
-       "      <td>4</td>\n",
-       "      <td>7</td>\n",
-       "      <td>Low</td>\n",
-       "      <td>Methylobacter</td>\n",
-       "      <td>6012817</td>\n",
-       "      <td>0.668513</td>\n",
-       "      <td>1056094</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              ID  rep  week   oxy          Genus   Length  abundance  project\n",
-       "2432   106_HOW12    4    12  High  Methylobacter  4325001   0.701923  1056226\n",
-       "42797   76_LOW10    4    10   Low  Methylobacter  6062067   0.701577  1056166\n",
-       "50891   94_HOW11    4    11  High  Methylobacter  5268714   0.698849  1056202\n",
-       "45856   82_HOW10    4    10  High  Methylobacter  5488758   0.693746  1056178\n",
-       "26673    40_LOW7    4     7   Low  Methylobacter  6012817   0.668513  1056094"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from abundance_utils import reduce_to_genus_only\n",
     "data_reduced_genus = reduce_to_genus_only(data_reduced)\n",
@@ -886,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -900,86 +808,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>ID</th>\n",
-       "      <th>rep</th>\n",
-       "      <th>week</th>\n",
-       "      <th>oxy</th>\n",
-       "      <th>Genus</th>\n",
-       "      <th>Length</th>\n",
-       "      <th>abundance</th>\n",
-       "      <th>project</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>2432</th>\n",
-       "      <td>106_HOW12</td>\n",
-       "      <td>4</td>\n",
-       "      <td>12</td>\n",
-       "      <td>High</td>\n",
-       "      <td>Methylobacter</td>\n",
-       "      <td>4325001</td>\n",
-       "      <td>0.701923</td>\n",
-       "      <td>1056226</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>42797</th>\n",
-       "      <td>76_LOW10</td>\n",
-       "      <td>4</td>\n",
-       "      <td>10</td>\n",
-       "      <td>Low</td>\n",
-       "      <td>Methylobacter</td>\n",
-       "      <td>6062067</td>\n",
-       "      <td>0.701577</td>\n",
-       "      <td>1056166</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>50891</th>\n",
-       "      <td>94_HOW11</td>\n",
-       "      <td>4</td>\n",
-       "      <td>11</td>\n",
-       "      <td>High</td>\n",
-       "      <td>Methylobacter</td>\n",
-       "      <td>5268714</td>\n",
-       "      <td>0.698849</td>\n",
-       "      <td>1056202</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              ID  rep  week   oxy          Genus   Length  abundance  project\n",
-       "2432   106_HOW12    4    12  High  Methylobacter  4325001   0.701923  1056226\n",
-       "42797   76_LOW10    4    10   Low  Methylobacter  6062067   0.701577  1056166\n",
-       "50891   94_HOW11    4    11  High  Methylobacter  5268714   0.698849  1056202"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "data_reduced_genus.head(3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -990,7 +830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -1014,7 +854,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "IPython (Python 3)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/calculate_abundances.ipynb
+++ b/calculate_abundances.ipynb
@@ -684,7 +684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -768,7 +768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -781,11 +781,103 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>rep</th>\n",
+       "      <th>week</th>\n",
+       "      <th>oxy</th>\n",
+       "      <th>Genus</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>abundance</th>\n",
+       "      <th>project</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2432</th>\n",
+       "      <td>106_HOW12</td>\n",
+       "      <td>4</td>\n",
+       "      <td>12</td>\n",
+       "      <td>High</td>\n",
+       "      <td>Methylobacter</td>\n",
+       "      <td>4325001</td>\n",
+       "      <td>0.701923</td>\n",
+       "      <td>1056226</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>42797</th>\n",
+       "      <td>76_LOW10</td>\n",
+       "      <td>4</td>\n",
+       "      <td>10</td>\n",
+       "      <td>Low</td>\n",
+       "      <td>Methylobacter</td>\n",
+       "      <td>6062067</td>\n",
+       "      <td>0.701577</td>\n",
+       "      <td>1056166</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50891</th>\n",
+       "      <td>94_HOW11</td>\n",
+       "      <td>4</td>\n",
+       "      <td>11</td>\n",
+       "      <td>High</td>\n",
+       "      <td>Methylobacter</td>\n",
+       "      <td>5268714</td>\n",
+       "      <td>0.698849</td>\n",
+       "      <td>1056202</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45856</th>\n",
+       "      <td>82_HOW10</td>\n",
+       "      <td>4</td>\n",
+       "      <td>10</td>\n",
+       "      <td>High</td>\n",
+       "      <td>Methylobacter</td>\n",
+       "      <td>5488758</td>\n",
+       "      <td>0.693746</td>\n",
+       "      <td>1056178</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26673</th>\n",
+       "      <td>40_LOW7</td>\n",
+       "      <td>4</td>\n",
+       "      <td>7</td>\n",
+       "      <td>Low</td>\n",
+       "      <td>Methylobacter</td>\n",
+       "      <td>6012817</td>\n",
+       "      <td>0.668513</td>\n",
+       "      <td>1056094</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              ID  rep  week   oxy          Genus   Length  abundance  project\n",
+       "2432   106_HOW12    4    12  High  Methylobacter  4325001   0.701923  1056226\n",
+       "42797   76_LOW10    4    10   Low  Methylobacter  6062067   0.701577  1056166\n",
+       "50891   94_HOW11    4    11  High  Methylobacter  5268714   0.698849  1056202\n",
+       "45856   82_HOW10    4    10  High  Methylobacter  5488758   0.693746  1056178\n",
+       "26673    40_LOW7    4     7   Low  Methylobacter  6012817   0.668513  1056094"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from abundance_utils import reduce_to_genus_only\n",
     "data_reduced_genus = reduce_to_genus_only(data_reduced)\n",
@@ -794,7 +886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -808,18 +900,86 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>rep</th>\n",
+       "      <th>week</th>\n",
+       "      <th>oxy</th>\n",
+       "      <th>Genus</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>abundance</th>\n",
+       "      <th>project</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2432</th>\n",
+       "      <td>106_HOW12</td>\n",
+       "      <td>4</td>\n",
+       "      <td>12</td>\n",
+       "      <td>High</td>\n",
+       "      <td>Methylobacter</td>\n",
+       "      <td>4325001</td>\n",
+       "      <td>0.701923</td>\n",
+       "      <td>1056226</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>42797</th>\n",
+       "      <td>76_LOW10</td>\n",
+       "      <td>4</td>\n",
+       "      <td>10</td>\n",
+       "      <td>Low</td>\n",
+       "      <td>Methylobacter</td>\n",
+       "      <td>6062067</td>\n",
+       "      <td>0.701577</td>\n",
+       "      <td>1056166</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50891</th>\n",
+       "      <td>94_HOW11</td>\n",
+       "      <td>4</td>\n",
+       "      <td>11</td>\n",
+       "      <td>High</td>\n",
+       "      <td>Methylobacter</td>\n",
+       "      <td>5268714</td>\n",
+       "      <td>0.698849</td>\n",
+       "      <td>1056202</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              ID  rep  week   oxy          Genus   Length  abundance  project\n",
+       "2432   106_HOW12    4    12  High  Methylobacter  4325001   0.701923  1056226\n",
+       "42797   76_LOW10    4    10   Low  Methylobacter  6062067   0.701577  1056166\n",
+       "50891   94_HOW11    4    11  High  Methylobacter  5268714   0.698849  1056202"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data_reduced_genus.head(3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "collapsed": true
    },
@@ -830,7 +990,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {
     "collapsed": true
    },

--- a/elviz_utils.py
+++ b/elviz_utils.py
@@ -78,7 +78,7 @@ def read_elviz_CSVs(directory):
     for filename in elviz_files:
         print(filename)
         # read the dataframe from the csv
-        df = read_elviz_CSV("./data/" + filename)
+        df = read_elviz_CSV(directory + filename)
         df['Log10 Average fold'] = numpy.log10(df['Average fold'])
         elviz_data[filename] = df
     return elviz_data

--- a/elviz_utils.py
+++ b/elviz_utils.py
@@ -96,7 +96,7 @@ def read_pickle_or_CSVs(pickle_filename, CSV_directory):
     else:
         # OK, no pickle found, do it the hard way
         print("reading in all Elviz CSV files")
-        elviz_data = read_elviz_CSVs(DATA_DIR)
+        elviz_data = read_elviz_CSVs(CSV_directory)
         # assemble the uber frame
         print("concatenating data frames prior to normalization")
         # create a combined dataframe from all the CSV files


### PR DESCRIPTION
The switch to python3 in line 1 should have been more highly emphasized in the commit message.  Instead of relying on the default python version this change explicitly calls for py35.  

Future branches would include making the DPGMM_N_COMPONENTS a command line argument and possible changes to the scalar used for normalization to make the transformed data more 'normal'.
